### PR TITLE
Fix mistyped $id in schema

### DIFF
--- a/neuron.schema.json
+++ b/neuron.schema.json
@@ -1,6 +1,6 @@
 {
     "$schema": "https://json-schema.org/draft/2019-09/schema",
-    "$id": "https://raw.githubusercontent.com/GenGeNN/GenGeNN-resources/master/neuron.json.schema",
+    "$id": "https://raw.githubusercontent.com/GenGeNN/GenGeNN-resources/master/neuron.schema.json",
     "title": "Neuron",
     "description": "A single neuron definition for GeNN JSON",
     "type": "object",


### PR DESCRIPTION
Small mistaken in my file... needs to be correct for schema to be valid -> be used for form construction.